### PR TITLE
WL-3909 Make sure dependencies are always met.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -38,6 +38,12 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <!-- As this dependency is used by termdates-impl even if tests are skipped we need to always
+                             build it, otherwise when building with an empty repository without tests enabled the
+                             dependency won't be found and the build will fail. -->
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This stops the build failing when the local repository is empty and tests are skipped.
